### PR TITLE
【マークアップ】商品出品ページ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,5 +3,6 @@
 @import "modules/header";
 @import "modules/footer";
 @import "modules/camera";
+@import "modules/sellcontents";
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/assets/stylesheets/modules/_camera.scss
+++ b/app/assets/stylesheets/modules/_camera.scss
@@ -8,13 +8,16 @@
   background-color: red;
   color: white;
   display: block;
+  z-index: 1;
   &--contents{
     font-size: 22px;
     margin-top: 25px;
     margin-left: 58px;
+    
   }
   .fa-camera{
     font-size: 60px;
     margin-left: 50px;
+    text-decoration: none;
   }
 }

--- a/app/assets/stylesheets/modules/_sellcontents.scss
+++ b/app/assets/stylesheets/modules/_sellcontents.scss
@@ -213,12 +213,13 @@
     width: 620px;
     margin: 0 auto;
     .production-price-header{
+    padding-top: 55px;
     color: gray;
     }
     &--black{
       font-weight: 600;
       line-height: 1.4em;
-      padding-top: 55px;
+      padding-top: 35px;
       padding-bottom: 55px;
       color:black;
       display: inline-block;

--- a/app/assets/stylesheets/modules/_sellcontents.scss
+++ b/app/assets/stylesheets/modules/_sellcontents.scss
@@ -1,0 +1,299 @@
+.product-page{
+  background-color: rgb(229, 242, 243);
+  width: 100%;
+  height: 100%;
+}
+
+.fmarket_logo{
+  text-align: center;
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
+
+.sellcontents{
+  width: 700px;
+  height: 2130px;
+  margin:  0 auto;
+  position: relative;
+  background-color: white;
+  margin-top: 20px;
+  .sellcontents-pict{
+    height: 330px;
+    
+    .sellcontents-pict-form{
+      position: relative;
+      width: 620px;
+      height: 220px;
+      margin:  0 auto;
+      top: 40px;
+      &--name{
+      font-size: 16px;
+      font-weight: 600;
+      line-height: 1.4em;
+      display: inline-block;
+      }
+      &--hissu{
+        margin-left: 8px;
+        font-size: 16px;
+        background-color: #ff0211;
+        color: white;
+        width: 34px;
+        font-weight: 600;
+        display: inline-block;
+      }
+      &--upload{
+        margin-top: 10px;
+      }
+      .sellcontents-pict-form-file{
+        height: 162px;
+        background-color:rgb(204, 204, 204);
+        text-align: center;
+        .fa-camera{
+          font-size: 20px;
+          padding-top: 55px;
+        }
+      }
+    }
+  }
+  .product-status{
+    height: 400px;
+    padding-top: 20px;
+    .product-status-nameform{
+      width: 620px;
+      height: 120px;
+      margin:  0 auto;
+      top: 30px;
+      &--name{
+        font-weight: 600;
+        line-height: 1.4em;
+        display: inline-block;
+        }
+      &--hissu{
+        margin-left: 8px;
+        font-size: 16px;
+        background-color: #ff0211;
+        color: white;
+        width: 34px;
+        font-weight: 600;
+        display: inline-block;
+       }
+      .name-form{
+        display:block;
+        margin-top:15px;
+        border-radius: 4px;
+        height: 48px;
+        width: 600px;
+        box-sizing: border-box;
+        border: 1px solid #ccc;
+      }
+    }
+    .product-status-textform{
+      width: 620px;
+      height: 240px;
+      margin:  0 auto;
+      .statusform{
+        display:block;
+        width: 600px;
+        margin-top:15px;
+        border-radius: 4px;
+        outline: none;
+        border: 1px solid #ccc;
+        box-sizing: border-box;
+        height: 200px;
+      }
+    }
+  }
+  
+  .product-detail{
+    height: 390px;
+    padding-top: 40px;
+    .product-detail-form{
+      height: 360px;
+      margin:  0 auto;
+      width: 620px;
+      &--head{
+        font-weight: 600;
+        line-height: 1.4em;
+        padding-bottom: 25px;
+        color: gray;
+        display: block;
+        
+      }
+      &--name{
+        font-weight: 600;
+        line-height: 1.4em;
+        display: inline-block;
+        padding-bottom: 15px;
+      }
+      &--hissu{
+        margin-left: 8px;
+        font-size: 16px;
+        background-color: #ff0211;
+        color: white;
+        width: 34px;
+        font-weight: 600;
+        display: inline-block;
+      }
+      &--tab{
+        position: relative;
+        margin-bottom: 35px;
+        select{
+          width: 600px;
+          height: 48px;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+          color: black;
+        }
+      }
+      &--ninni{
+        margin-left: 8px;
+        font-size: 16px;
+        background-color: gray;
+        color: white;
+        width: 34px;
+        font-weight: 600;
+        display: inline-block;
+      }
+      .name-form{
+        display:block;
+        border-radius: 4px;
+        height: 48px;
+        width: 600px;
+        box-sizing: border-box;
+        border: 1px solid #ccc;
+        margin-bottom: 35px;
+      }
+    }
+  }
+  .production-delivery{
+    height: 450px;
+    padding-top: 60px;
+    .production-delivery-form{
+      width: 620px;
+      height: 380px;
+      margin:  0 auto;
+      background-color: white;
+      &--exp{
+        font-weight: 600;
+        line-height: 1.4em;
+        padding-bottom: 25px;
+        color: gray;
+        display: block;
+      }
+      &--black{
+        font-weight: 600;
+        line-height: 1.4em;
+        display: inline-block;
+        padding-bottom: 15px;
+      }
+      &--hissu{
+        margin-left: 8px;
+        font-size: 16px;
+        background-color: #ff0211;
+        color: white;
+        width: 34px;
+        font-weight: 600;
+        display: inline-block;
+      }
+      &--tab{
+        position: relative;
+        margin-bottom: 35px;
+        select{
+          width: 600px;
+          height: 48px;
+          border: 1px solid #ccc;
+          border-radius: 4px;
+          color: black;
+        }
+      }
+    }
+  }
+  .production-price{
+    width: 620px;
+    margin: 0 auto;
+    .production-price-header{
+    color: gray;
+    }
+    &--black{
+      font-weight: 600;
+      line-height: 1.4em;
+      padding-top: 55px;
+      padding-bottom: 55px;
+      color:black;
+      display: inline-block;
+    }
+    &--hissu{
+      margin-left: 8px;
+      font-size: 16px;
+      background-color: #ff0211;
+      color: white;
+      width: 34px;
+      font-weight: 600;
+      display: inline-block;
+    }
+    &--mark{
+      padding-left: 200px;
+      display: inline-block;
+    }
+    .priceform{
+      height: 44px;
+      width: 265px;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      text-align: right;
+    }
+    .production-price-commision{
+      color: gray;
+      padding-bottom: 35px;
+      &--charge{
+        display: inline-block;
+        padding-left: 164px;
+      }
+    }
+    
+    .production-price-profit{
+      color: gray;
+      margin-bottom: 65px;
+      &--charge{
+        display: inline-block;
+        padding-left: 248px;
+      }
+    }
+  }
+  .decideform{
+    width: 620px;
+    height: 300px;
+    margin: 0 auto;
+    .decideform-sellicon{
+      margin-left: 170px;
+      background-color: #ea352d;
+      color: #fff;
+      text-align: center;
+      font-size: 17px;
+      min-height: 48px;
+      font-weight: 600;
+      margin-bottom: 25px;
+      border-radius: 4px;
+      width: 300px;
+      display: block;
+    }
+    .decideform-returnicon{
+      margin-left: 170px;
+      background-color: #cccccc;
+      color:black;
+      text-align: center;
+      font-size: 17px;
+      min-height: 48px;
+      font-weight: 600;
+      margin-bottom: 25px;
+      border-radius: 4px;
+      width: 300px;
+      display: block;
+    }
+    .decideform-alert{
+      font-size: 12px;
+      color: gray;
+    }
+  }
+}

--- a/app/controllers/sellcontents_controller.rb
+++ b/app/controllers/sellcontents_controller.rb
@@ -1,0 +1,7 @@
+class SellcontentsController < ApplicationController
+  def create
+  end
+
+  def new
+  end
+end

--- a/app/helpers/sellcontents_helper.rb
+++ b/app/helpers/sellcontents_helper.rb
@@ -1,0 +1,2 @@
+module SellcontentsHelper
+end

--- a/app/views/posts/sellcontents.html.haml
+++ b/app/views/posts/sellcontents.html.haml
@@ -42,21 +42,21 @@
           必須
         .product-detail-form--tab
           %select{name:"categoryId"}
-            %option{"aria-selected" => "true",label:"選択してください",selected:"selected",value:""} 選択してください
-            %option{"aria-selected" => "false",label:"レディース",value:"1"} レディース
-            %option{"aria-selected" => "false",label:"メンズ",value:"2"} メンズ
-            %option{"aria-selected" => "false",label:"ベビー・キッズ",value:"3"} ベビー・キッズ
-            %option{"aria-selected" => "false",label:"インテリア・住まい・小物",value:"4"} インテリア・住まい・小物
-            %option{"aria-selected" => "false",label:"本・音楽・ゲーム",value:"5"} 本・音楽・ゲーム
-            %option{"aria-selected" => "false",label:"おもちゃ・ホビー・グッズ",value:"1328"} おもちゃ・ホビー・グッズ
-            %option{"aria-selected" => "false",label:"コスメ・香水・美容",value:"6"} コスメ・香水・美容
-            %option{"aria-selected" => "false",label:"家電・スマホ・カメラ",value:"7"} 家電・スマホ・カメラ
-            %option{"aria-selected" => "false",label:"スポーツ・レジャー",value:"8"} スポーツ・レジャー
-            %option{"aria-selected" => "false",label:"ハンドメイド",value:"9"} ハンドメイド
-            %option{"aria-selected" => "false",label:"チケット",value:"1027"} チケット
-            %option{"aria-selected" => "false",label:"自動車・オートバイ",value:"1318"} 自動車・オートバイ
-            %option{"aria-selected" => "false",label:"その他",value:"10"} その他
-            %svg{"aria-hidden" => "true",fill:"#888888", "fill-rule" => "evenodd",height:"24",viewbox:"0 0 24 24",width:"24"}
+            %option{ aria: "true",label:"選択してください",selected:"selected",value:""} 選択してください
+            %option{ aria: "false",label:"レディース",value:"1"} レディース
+            %option{ aria: "false",label:"メンズ",value:"2"} メンズ
+            %option{ aria: "false",label:"ベビー・キッズ",value:"3"} ベビー・キッズ
+            %option{ aria: "false",label:"インテリア・住まい・小物",value:"4"} インテリア・住まい・小物
+            %option{ aria: "false",label:"本・音楽・ゲーム",value:"5"} 本・音楽・ゲーム
+            %option{ aria: "false",label:"おもちゃ・ホビー・グッズ",value:"1328"} おもちゃ・ホビー・グッズ
+            %option{ aria: "false",label:"コスメ・香水・美容",value:"6"} コスメ・香水・美容
+            %option{ aria: "false",label:"家電・スマホ・カメラ",value:"7"} 家電・スマホ・カメラ
+            %option{ aria: "false",label:"スポーツ・レジャー",value:"8"} スポーツ・レジャー
+            %option{ aria: "false",label:"ハンドメイド",value:"9"} ハンドメイド
+            %option{ aria: "false",label:"チケット",value:"1027"} チケット
+            %option{ aria: "false",label:"自動車・オートバイ",value:"1318"} 自動車・オートバイ
+            %option{ aria: "false",label:"その他",value:"10"} その他
+            %svg{ aria: "true",fill:"#888888", rule: "evenodd",height:"24",viewbox:"0 0 24 24",width:"24"}
         
         .product-detail-form--name
           ブランド
@@ -69,13 +69,13 @@
           必須
         .product-detail-form--tab
           %select{name:"itemCondition"}
-            %option{"aria-selected" => "true",label:"選択してください",selected:"selected",value:""} 選択してください
-            %option{"aria-selected" => "false",label:"新品、未使用",value:"1"} 新品、未使用
-            %option{"aria-selected" => "false",label:"未使用に近い",value:"2"} 未使用に近い
-            %option{"aria-selected" => "false",label:"目立った傷や汚れなし",value:"3"} 目立った傷や汚れなし
-            %option{"aria-selected" => "false",label:"やや傷や汚れあり",value:"4"} やや傷や汚れあり
-            %option{"aria-selected" => "false",label:"傷や汚れあり",value:"5"} 傷や汚れあり
-            %option{"aria-selected" => "false",label:"全体的に状態が悪い",value:"6"} 全体的に状態が悪い
+            %option{ aria:"true",label:"選択してください",selected:"selected",value:""} 選択してください
+            %option{ aria: "false",label:"新品、未使用",value:"1"} 新品、未使用
+            %option{ aria: "false",label:"未使用に近い",value:"2"} 未使用に近い
+            %option{ aria: "false",label:"目立った傷や汚れなし",value:"3"} 目立った傷や汚れなし
+            %option{ aria: "false",label:"やや傷や汚れあり",value:"4"} やや傷や汚れあり
+            %option{ aria: "false",label:"傷や汚れあり",value:"5"} 傷や汚れあり
+            %option{ aria: "false",label:"全体的に状態が悪い",value:"6"} 全体的に状態が悪い
     
     .production-delivery
       .production-delivery-form
@@ -87,27 +87,27 @@
           必須
         .production-delivery-form--tab
           %select{name:"shippingPayer"}
-            %option{"aria-selected" => "true",label:"選択してください",selected:"selected",value:""} 選択してください
-            %option{"aria-selected" => "false",label:"送料込み(出品者負担)",value:"2"} 送料込み(出品者負担)
-            %option{"aria-selected" => "false",label:"着払い(購入者負担)",value:"1"} 着払い(購入者負担)
+            %option{ aria: "true",label:"選択してください",selected:"selected",value:""} 選択してください
+            %option{ aria: "false",label:"送料込み(出品者負担)",value:"2"} 送料込み(出品者負担)
+            %option{ aria: "false",label:"着払い(購入者負担)",value:"1"} 着払い(購入者負担)
         .production-delivery-form--black
           発送元の地域
         .production-delivery-form--hissu
           必須
         .production-delivery-form--tab
           %select{name:"shippingarea"}
-            %option{"aria-selected" => "true",label:"選択してください",selected:"selected",value:""} 選択してください
-            %option{"aria-selected" => "false",label:"北海道",value:"2"} 北海道
-            %option{"aria-selected" => "false",label:"東北",value:"1"} 東北
+            %option{ aria: "true",label:"選択してください",selected:"selected",value:""} 選択してください
+            %option{ aria: "false",label:"北海道",value:"2"} 北海道
+            %option{ aria: "false",label:"東北",value:"1"} 東北
         .production-delivery-form--black
           発送までの日数
         .production-delivery-form--hissu
           必須
         .production-delivery-form--tab
           %select{name:"shippingday"}
-            %option{"day-selected" => "true",label:"選択してください",selected:"selected",value:""} 選択してください
-            %option{"day-selected" => "false",label:"1~2日",value:"2"} 1~2日
-            %option{"day-selected" => "false",label:"3~4日",value:"1"} 3~4日
+            %option{day: "true",label:"選択してください",selected:"selected",value:""} 選択してください
+            %option{day: "false",label:"1~2日",value:"2"} 1~2日
+            %option{day: "false",label:"3~4日",value:"1"} 3~4日
     
     .production-price
       .production-price-header

--- a/app/views/posts/sellcontents.html.haml
+++ b/app/views/posts/sellcontents.html.haml
@@ -1,0 +1,139 @@
+.product-page
+  .fmarket_logo
+    =image_tag "#{asset_path "fmarket_logo.png"}",size: '185x55',alt:"fmarket"
+
+  .sellcontents
+    .sellcontents-pict
+      .sellcontents-pict-form
+        .sellcontents-pict-form--name
+          出品画像
+        .sellcontents-pict-form--hissu
+          必須
+        .sellcontents-pict-form--upload
+          最大4枚までアップロードできます
+        .sellcontents-pict-form-file
+          %i.fas.fa-camera
+          .camera-text
+            ドラッグアンドドロップ
+          .camera-text2
+            またはクリックしてファイルをアップロード
+    .product-status
+      .product-status-nameform
+        .product-status-nameform--name
+          商品名
+        .product-status-nameform--hissu
+          必須
+        %input.name-form{autocomplete:"off",name:"name",placeholder:"40文字まで",type:"text",value:""}/
+
+      .product-status-textform
+        .product-status-nameform--name
+          商品の説明
+        .product-status-nameform--hissu
+          必須
+        %textarea.statusform{autocomplete:"off",name:"name",type:"text",placeholder:"商品の説明（必須 1,000文字以内）\n（色、素材、重さ、定価、注意点など）\n\n例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。\n          ",value:""}
+  
+    .product-detail
+      .product-detail-form
+        .product-detail-form--head
+          商品の詳細
+        .product-detail-form--name
+          カテゴリー
+        .product-detail-form--hissu
+          必須
+        .product-detail-form--tab
+          %select{name:"categoryId"}
+            %option{"aria-selected" => "true",label:"選択してください",selected:"selected",value:""} 選択してください
+            %option{"aria-selected" => "false",label:"レディース",value:"1"} レディース
+            %option{"aria-selected" => "false",label:"メンズ",value:"2"} メンズ
+            %option{"aria-selected" => "false",label:"ベビー・キッズ",value:"3"} ベビー・キッズ
+            %option{"aria-selected" => "false",label:"インテリア・住まい・小物",value:"4"} インテリア・住まい・小物
+            %option{"aria-selected" => "false",label:"本・音楽・ゲーム",value:"5"} 本・音楽・ゲーム
+            %option{"aria-selected" => "false",label:"おもちゃ・ホビー・グッズ",value:"1328"} おもちゃ・ホビー・グッズ
+            %option{"aria-selected" => "false",label:"コスメ・香水・美容",value:"6"} コスメ・香水・美容
+            %option{"aria-selected" => "false",label:"家電・スマホ・カメラ",value:"7"} 家電・スマホ・カメラ
+            %option{"aria-selected" => "false",label:"スポーツ・レジャー",value:"8"} スポーツ・レジャー
+            %option{"aria-selected" => "false",label:"ハンドメイド",value:"9"} ハンドメイド
+            %option{"aria-selected" => "false",label:"チケット",value:"1027"} チケット
+            %option{"aria-selected" => "false",label:"自動車・オートバイ",value:"1318"} 自動車・オートバイ
+            %option{"aria-selected" => "false",label:"その他",value:"10"} その他
+            %svg{"aria-hidden" => "true",fill:"#888888", "fill-rule" => "evenodd",height:"24",viewbox:"0 0 24 24",width:"24"}
+        
+        .product-detail-form--name
+          ブランド
+        .product-detail-form--ninni
+          任意
+        %input.name-form{autocomplete:"off",name:"brandName",placeholder:"例）シャネル",type:"text",value:""}/
+        .product-detail-form--name
+          商品の状態
+        .product-detail-form--hissu
+          必須
+        .product-detail-form--tab
+          %select{name:"itemCondition"}
+            %option{"aria-selected" => "true",label:"選択してください",selected:"selected",value:""} 選択してください
+            %option{"aria-selected" => "false",label:"新品、未使用",value:"1"} 新品、未使用
+            %option{"aria-selected" => "false",label:"未使用に近い",value:"2"} 未使用に近い
+            %option{"aria-selected" => "false",label:"目立った傷や汚れなし",value:"3"} 目立った傷や汚れなし
+            %option{"aria-selected" => "false",label:"やや傷や汚れあり",value:"4"} やや傷や汚れあり
+            %option{"aria-selected" => "false",label:"傷や汚れあり",value:"5"} 傷や汚れあり
+            %option{"aria-selected" => "false",label:"全体的に状態が悪い",value:"6"} 全体的に状態が悪い
+    
+    .production-delivery
+      .production-delivery-form
+        .production-delivery-form--exp
+          配送について
+        .production-delivery-form--black
+          配送料の負担
+        .production-delivery-form--hissu
+          必須
+        .production-delivery-form--tab
+          %select{name:"shippingPayer"}
+            %option{"aria-selected" => "true",label:"選択してください",selected:"selected",value:""} 選択してください
+            %option{"aria-selected" => "false",label:"送料込み(出品者負担)",value:"2"} 送料込み(出品者負担)
+            %option{"aria-selected" => "false",label:"着払い(購入者負担)",value:"1"} 着払い(購入者負担)
+        .production-delivery-form--black
+          発送元の地域
+        .production-delivery-form--hissu
+          必須
+        .production-delivery-form--tab
+          %select{name:"shippingarea"}
+            %option{"aria-selected" => "true",label:"選択してください",selected:"selected",value:""} 選択してください
+            %option{"aria-selected" => "false",label:"北海道",value:"2"} 北海道
+            %option{"aria-selected" => "false",label:"東北",value:"1"} 東北
+        .production-delivery-form--black
+          発送までの日数
+        .production-delivery-form--hissu
+          必須
+        .production-delivery-form--tab
+          %select{name:"shippingday"}
+            %option{"day-selected" => "true",label:"選択してください",selected:"selected",value:""} 選択してください
+            %option{"day-selected" => "false",label:"1~2日",value:"2"} 1~2日
+            %option{"day-selected" => "false",label:"3~4日",value:"1"} 3~4日
+    
+    .production-price
+      .production-price-header
+        価格（¥300〜9,999,999）
+      .production-price--black
+        販売価格
+      .production-price--hissu
+        必須
+      .production-price--mark
+        ¥
+      %input.priceform{autocomplete:"off",name:"price",placeholder:"0",type:"number",value:""}/
+      
+      .production-price-commision
+        販売手数料（10%）
+        .production-price-commision--charge
+          ¥
+      .production-price-profit
+        販売利益     
+        .production-price-profit--charge
+          ¥
+    .decideform
+      %button.decideform-sellicon{tabindex:"0",type:"submit"} 出品する
+      %button.decideform-returnicon{tabindex:"0",type:"submit"} もどる
+      .decideform-alert
+        禁止されている行為および出品物を必ずご確認ください。偽ブランド品や盗品物などの販売は犯罪であり、法律により処罰される可能性があります。 また、出品をもちまして加盟店規約に同意したことになります。
+  .fmarket_logo
+    =image_tag "#{asset_path "fmarket_logo.png"}",size: '185x55',alt:"fmarket"
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'posts/index'
-  get 'posts/sellcontents'
   root "posts#index"
+  resources :sellcontents, only: [:new, :create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get 'posts/index'
+  get 'posts/sellcontents'
   root "posts#index"
 end

--- a/test/controllers/sellcontents_controller_test.rb
+++ b/test/controllers/sellcontents_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SellcontentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# WHAT
商品出品ページの実装
haml scssを用いてマークアップ、posts/sellcontentsで確認できる様に調整をルーティングに追記

# WHY
フリマアプリの基礎的機能部分だから

![出品１](https://user-images.githubusercontent.com/57036291/75089815-08dc3900-55a0-11ea-8de1-9bc28aa4a9d0.png)
![出品２](https://user-images.githubusercontent.com/57036291/75089817-10034700-55a0-11ea-9261-8bea1c2f9ced.png)
![出品３](https://user-images.githubusercontent.com/57036291/75089818-142f6480-55a0-11ea-9762-6aba90718d42.png)
![出品４](https://user-images.githubusercontent.com/57036291/75089823-185b8200-55a0-11ea-9568-e3731977db65.png)
