### PR TITLE
パンくずリスト

### DIFF
--- a/app/views/check/_header-menu-check.html.haml
+++ b/app/views/check/_header-menu-check.html.haml
@@ -1,10 +1,4 @@
 .header-menu
   %ul.menu-content
-    %li.menu-content__title
-      フリーマーケット
-      = icon('fas', 'chevron-right')
-    %li.menu-content__mypage
-      マイページ
-      = icon('fas', 'chevron-right')
-    %li.menu-content__check
-      本人情報の登録
+    - breadcrumb :check
+    = render "layouts/breadcrumbs"

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/app/views/mypage/_header-menu-mypage.html.haml
+++ b/app/views/mypage/_header-menu-mypage.html.haml
@@ -1,8 +1,5 @@
 .header-menu
   %ul.menu-content
-    %li.menu-content__title
-      = link_to "エフマーケット",root_path
-      = icon('fas', 'chevron-right')
-    %li.menu-content__mypage
-      マイページ
+    - breadcrumb :mypage
+    = render "layouts/breadcrumbs"
       

--- a/app/views/mypage/_left_box-mypage.html.haml
+++ b/app/views/mypage/_left_box-mypage.html.haml
@@ -71,8 +71,9 @@
         メール/パスワード
         = icon('fas', 'chevron-right')
       %li.left-box3__lists__list
-        本人情報
-        = icon('fas', 'chevron-right')
+        = link_to check_index_path do
+          本人情報
+          = icon('fas', 'chevron-right')
       %li.left-box3__lists__list
         電話番号の確認
         = icon('fas', 'chevron-right')

--- a/app/views/profile/_header-menu-profile.html.haml
+++ b/app/views/profile/_header-menu-profile.html.haml
@@ -1,11 +1,5 @@
 .header-menu
   %ul.menu-content
-    %li.menu-content__title
-      フリーマーケット
-      = icon('fas', 'chevron-right')
-    %li.menu-content__mypage
-      マイページ
-      = icon('fas', 'chevron-right')
-    %li.menu-content__profile
-      プロフィール
+    - breadcrumb :profile
+    = render "layouts/breadcrumbs"
     

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,42 @@
+crumb :root do
+  link "トップページ", root_path
+end
+
+crumb :mypage do
+  link "マイページ", mypage_index_path
+end
+
+crumb :profile do
+  link "プロフィール", profile_index_path
+  parent :mypage
+end
+
+crumb :check do
+  link "本人情報の登録", check_index_path
+  parent :mypage
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
#What
ユーザーが今WEBサイト内のどの位置にいるのかを視覚的に分かりやすくするため、上位の階層となるWEBページを階層順にリストアップしてリンクを設置したリストの作成

#Why
ページ移動を楽にする為。